### PR TITLE
Add Ship Tech

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slipdash",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/dashboard/[playerId]/[protocol]/[address]/[...path]/page.tsx
+++ b/src/app/dashboard/[playerId]/[protocol]/[address]/[...path]/page.tsx
@@ -13,7 +13,7 @@ export default async function Page({
 }) {
     const { protocol, address, playerId, path } = await params;
 
-    let decodedAddress = decodeURIComponent(address);
+    const decodedAddress = decodeURIComponent(address);
 
     const baseUrl = `${protocol}://${decodedAddress}/${path.join("/")}`;
 

--- a/src/app/dashboard/[playerId]/[protocol]/[address]/[...path]/page.tsx
+++ b/src/app/dashboard/[playerId]/[protocol]/[address]/[...path]/page.tsx
@@ -13,7 +13,9 @@ export default async function Page({
 }) {
     const { protocol, address, playerId, path } = await params;
 
-    const baseUrl = `${protocol}://${address}/${path.join("/")}`;
+    let decodedAddress = decodeURIComponent(address);
+
+    const baseUrl = `${protocol}://${decodedAddress}/${path.join("/")}`;
 
     return (
         <div className="flex flex-col min-h-screen">
@@ -27,7 +29,7 @@ export default async function Page({
             </main>
             <footer className="w-full p-4 text-center bg-gray-800 text-white flex flex-row items-center gap-5 justify-center">
                 <Link href="/">Return to Setup</Link>
-                <p>SlipDash v0.1</p>
+                <Link target="_blank" href="https://github.com/MoSadie/SlipDash">SlipDash v0.2</Link>
                 <Version baseUrl={baseUrl} />
                 <p>Made by <Link target="_blank" href="https://hello.mosadie.com">MoSadie</Link></p>
             </footer>

--- a/src/app/dashboard/components/shipInfo.tsx
+++ b/src/app/dashboard/components/shipInfo.tsx
@@ -20,6 +20,9 @@ export default function ShipInfo({ baseUrl }: { baseUrl: string }) {
 
     const healthPercentage = Math.round((currentHealth / currentMaxHealth) * 100);
 
+    const shipTech = shipData.shipTech || [];
+    const activeShipTech = shipTech.filter((tech: { IsActive: boolean; }) => tech.IsActive);
+
 
     if (selfError) return <div className={className}>Error loading self data</div>;
     if (selfIsLoading) return <div className={className}>Loading self data...</div>;
@@ -40,13 +43,29 @@ export default function ShipInfo({ baseUrl }: { baseUrl: string }) {
     const backgroundColor = healthPercentage < 25 ? "from-red-500" : (fullyHealedCrewMembers < crewList.length || healthPercentage < 100) ? "from-yellow-500" : "from-green-500";
 
     return (
-        <div className={className + " bg-linear-to-r " + backgroundColor}>
+        <div className={className + " bg-linear-to-r " + backgroundColor + " flex justify-between items-start"}>
+            <div id="left" className="flex-1 mr-4">
             <p>Ship Status:</p>
             <p>Health: {Math.round(currentHealth)}/{Math.round(currentMaxHealth)} ({healthPercentage}%)</p>
             {showCaptainInfo ? <p>Fuel: {shipData.currentFuel}/{shipData.maxFuel}</p> : ""}
             {showCaptainInfo ? <p>Salvage: {shipData.currentSalvage}</p> : ""}
             <p>Gems: {shipData.currentGems}</p>
             <p>Fully Healed Crew Members: {fullyHealedCrewMembers}/{crewList.length} ({fullyHealedCrewMembersPercentage}%)</p>
+            </div>
+            <div id="right" className="flex-1 ml-4">
+            <p>Active Ship Tech:</p>
+            {activeShipTech.length > 0 ? (
+                <ul>
+                {activeShipTech.map((tech: { Name: string; ShortDescription: string; Level: number; MaxLevel: number }, index: number) => (
+                    <li key={index} title={tech.ShortDescription}>
+                    <strong>{tech.Name}</strong>:  (Level {tech.Level}/{tech.MaxLevel})
+                    </li>
+                ))}
+                </ul>
+            ) : (
+                <p>No active ship tech</p>
+            )}
+            </div>
         </div>
     )
 }

--- a/src/app/dashboard/components/shipInfo.tsx
+++ b/src/app/dashboard/components/shipInfo.tsx
@@ -58,7 +58,7 @@ export default function ShipInfo({ baseUrl }: { baseUrl: string }) {
                 <ul>
                 {activeShipTech.map((tech: { Name: string; ShortDescription: string; Level: number; MaxLevel: number; UnitType: number, Levels: { [key: number]: { Level: number, Value: number, Cost: number; } } }, index: number) => (
                     <li key={index} title={tech.ShortDescription + (tech.Levels && (tech.Level - 1) in tech.Levels ? ` (Current Value: ${tech.Levels[tech.Level - 1].Value}${ShipTechUnitToSymbol(tech.UnitType)})` : "")}>
-                    <strong>{tech.Name}</strong>:  (Level {tech.Level}/{tech.MaxLevel})
+                    {tech.Name}:  (Level {tech.Level}/{tech.MaxLevel})
                     </li>
                 ))}
                 </ul>

--- a/src/app/dashboard/components/shipInfo.tsx
+++ b/src/app/dashboard/components/shipInfo.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { FetchCrewList, FetchSelf, FetchShipInfo } from "@/app/util";
+import { FetchCrewList, FetchSelf, FetchShipInfo, ShipTechUnitToSymbol } from "@/app/util";
 
 const className = "shadow-lg/25 rounded-md ring p-1 item-center justify-center text-left bg-gray-500";
 
@@ -56,8 +56,8 @@ export default function ShipInfo({ baseUrl }: { baseUrl: string }) {
             <p>Active Ship Tech:</p>
             {activeShipTech.length > 0 ? (
                 <ul>
-                {activeShipTech.map((tech: { Name: string; ShortDescription: string; Level: number; MaxLevel: number }, index: number) => (
-                    <li key={index} title={tech.ShortDescription}>
+                {activeShipTech.map((tech: { Name: string; ShortDescription: string; Level: number; MaxLevel: number; UnitType: number, Levels: { [key: number]: { Level: number, Value: number, Cost: number; } } }, index: number) => (
+                    <li key={index} title={tech.ShortDescription + (tech.Levels && (tech.Level - 1) in tech.Levels ? ` (Current Value: ${tech.Levels[tech.Level - 1].Value}${ShipTechUnitToSymbol(tech.UnitType)})` : "")}>
                     <strong>{tech.Name}</strong>:  (Level {tech.Level}/{tech.MaxLevel})
                     </li>
                 ))}

--- a/src/app/util.tsx
+++ b/src/app/util.tsx
@@ -22,6 +22,8 @@ export const FetchVersion = (url: string) => {
         refreshInterval: requestRefreshInterval,
     });
 
+    if (error) console.error("Error fetching version:", error);
+
     return { versionData: data, error, isLoading };
 };
 
@@ -29,6 +31,8 @@ export const FetchShipInfo = (url: string) => {
     const { data, error, isLoading } = useSWR(url + "/getShipInfo", fetcher, {
         refreshInterval: requestRefreshInterval,
     });
+
+    if (error) console.error("Error fetching ship info:", error);
 
     return { shipData: data, error, isLoading };
 };
@@ -38,11 +42,15 @@ export const FetchCrewList = (url: string) => {
         refreshInterval: requestRefreshInterval,
     });
 
+    if (error) console.error("Error fetching crew list:", error);
+
     return { crewList: (data?.crewList as Crew[]), error, isLoading };
 };
 
 export const FetchCrewById = (url: string, playerId: string) => {
     const { crewList, error, isLoading } = FetchCrewList(url);
+
+    if (error) console.error("Error fetching crew by ID:", error);
 
     let character = null;
 
@@ -54,6 +62,8 @@ export const FetchCrewById = (url: string, playerId: string) => {
 
 export const FetchSelf = (url: string) => {
     const { crewList, error, isLoading } = FetchCrewList(url);
+
+    if (error) console.error("Error fetching self:", error);
 
     let self = null;
     
@@ -67,6 +77,8 @@ export const FetchEnemyInfo = (url: string) => {
     const { data, error, isLoading } = useSWR(url + "/getEnemyShipInfo", fetcher, {
         refreshInterval: requestRefreshInterval,
     });
+
+    if (error) console.error("Error fetching enemy ship info:", error);
 
     return { enemyData: data?.enemyShip, error, isLoading };
 }

--- a/src/app/util.tsx
+++ b/src/app/util.tsx
@@ -112,3 +112,16 @@ export function archetypeToAvatar(archetype: string) {
             return <Image className={avatarClassName} src={AvatarDefault} alt="A space background" />;
     }
 }
+
+export function ShipTechUnitToSymbol(unit: number) {
+    switch (unit) {
+        case 0:
+            return ""; // VALUE - no unit
+        case 1:
+            return "%"; // PERCENTAGE
+        case 2:
+            return "s"; // SECONDS
+        default:
+            return ""; // Unknown unit
+    }
+}


### PR DESCRIPTION
Requires an update to SlipInfo 1.0.7 (Already made, just need to publish.)

Adds ability to show active ship tech and values on the ship info panel. Does not require SlipInfo host to have any role, since all crew can *view* the tech and levels at the engineering station.

Also, this update fixes the issue where having a port in the address would not work, breaking the default local address functionality.

This PR has been tested using the new SlipInfo build, and is working.